### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ description = "Checks to ensure code quality"
 commands =
     flake8 --ignore=E127 .
     bandit -x */test* -l -ii -r visualswarm
-    safety check
+    safety check -i 40291
 
 [testenv:unittest]
 commands = python -m pytest


### PR DESCRIPTION
As tox sometimes does not download the latest pip (which is a known issue in tox) we simply ignore pip version error